### PR TITLE
moment.js should be loaded from canonical path instead of bower_components

### DIFF
--- a/calendar-select.html
+++ b/calendar-select.html
@@ -1,6 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 
-<script src="bower_components/moment/min/moment.min.js"></script>
+<script src="../moment/min/moment.min.js"></script>
 
 <!--
 A sweet calendar selector widget!


### PR DESCRIPTION
See [aaronpanch/calendar-select #2](https://github.com/aaronpanch/calendar-select/pull/2).
